### PR TITLE
add api use to define packages that are necessary

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,7 +2,8 @@ Package.describe({
 	summary: "Meteor DB proxy"
 });
 
-Package.on_use(function (api) {    
+Package.on_use(function (api) {
+	api.use(["ecmascript", "underscore", "mongo"]);  
 	api.add_files("proxy.js", ["server", "client"]);
 	api.export("MeteorDBProxy");
 });


### PR DESCRIPTION
This helps the `meteor test-packages` run correctly
